### PR TITLE
fix: prevent tag overlaps

### DIFF
--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -41,12 +41,12 @@ export const buildTree = function(
     if (settings.output === "mathml") {
         return  buildMathML(tree, expression, options, settings.displayMode, true);
     } else if (settings.output === "html") {
-        const htmlNode = buildHTML(tree, options);
+        const htmlNode = buildHTML(tree, options, settings.displayMode);
         katexNode = buildCommon.makeSpan(["katex"], [htmlNode]);
     } else {
         const mathMLNode = buildMathML(tree, expression, options,
             settings.displayMode, false);
-        const htmlNode = buildHTML(tree, options);
+        const htmlNode = buildHTML(tree, options, settings.displayMode);
         katexNode = buildCommon.makeSpan(["katex"], [mathMLNode, htmlNode]);
     }
 
@@ -59,7 +59,7 @@ export const buildHTMLTree = function(
     settings: Settings,
 ): DomSpan {
     const options = optionsFromSettings(settings);
-    const htmlNode = buildHTML(tree, options);
+    const htmlNode = buildHTML(tree, options, settings.displayMode);
     const katexNode = buildCommon.makeSpan(["katex"], [htmlNode]);
     return displayWrap(katexNode, settings);
 };

--- a/src/katex.less
+++ b/src/katex.less
@@ -239,6 +239,10 @@
         max-width: 0; // necessary for Safari
     }
 
+    .glue {
+        flex-grow: 1;
+    }
+
     .msupsub {
         text-align: left;
     }
@@ -645,24 +649,20 @@
     > .katex {
         display: block;
         text-align: center;
-        white-space: nowrap;
 
         > .katex-html {
-            display: block;
-            position: relative;
-
-            > .tag {
-                position: absolute;
-                right: 0;
-            }
+            display: -ms-inline-flexbox;
+            display: inline-flex;
+            -ms-flex-direction: row;
+            flex-direction: row;
+            width: 100%;
         }
     }
 }
 
 // Left-justified tags (default is right-justified)
 .katex-display.leqno > .katex > .katex-html > .tag {
-    left: 0;
-    right: auto;
+    order: -1;
 }
 
 // Flush-left display math


### PR DESCRIPTION
This PR is a clone of #2343.

> Prevent a \tag or an equation number from overlapping a long equation. This PR renders display mode using flexbox CSS. Glue elements are written to set the equation element and the tag element in their proper position.
>
> Addresses issues #1983 & #2322.